### PR TITLE
fix: include build step during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
         run: npm clean-install
       - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
         run: npm audit signatures
+      - name: Build
+        run: npm run build
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Since v1.0.0, the package has been published without the `/lib` folder:

<img width="801" alt="image" src="https://github.com/user-attachments/assets/eb7a4c6a-4b58-4a70-9e27-1aa4aae7041d">

<img width="797" alt="image" src="https://github.com/user-attachments/assets/9c9e54ec-e424-4bfb-b61f-179b88ece9ab">
