### PR TITLE
feat: allow an arbitrary session transcript

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ import fs from "node:fs";
 
 ## Generating a device response
 
+### Using a OID4VP handover
+
 ```js
 import { DeviceResponse } from "@auth0/mdl";
 (() => {
@@ -124,6 +126,46 @@ import { DeviceResponse } from "@auth0/mdl";
     deviceResponseMDoc = await DeviceResponse.from(issuerMDoc)
       .usingPresentationDefinition(PRESENTATION_DEFINITION_1)
       .usingHandover([mdocGeneratedNonce, clientId, responseUri, verifierGeneratedNonce])
+      .authenticateWithSignature(devicePrivateKey, 'ES256')
+      .sign();
+  }
+})();
+```
+
+### Using an arbitrary session transcript
+
+```js
+import { DeviceResponse } from "@auth0/mdl";
+(() => {
+  let issuerMDoc;
+  let deviceResponseMDoc;
+
+  // This is what the MDL issuer does to generate a credential:
+  {
+    const document = await new Document('org.iso.18013.5.1.mDL')
+      .addIssuerNameSpace('org.iso.18013.5.1', {
+        family_name: 'Jones',
+        given_name: 'Ava',
+        birth_date: '2007-03-25',
+      })
+      .useDigestAlgorithm('SHA-256')
+      .addValidityInfo({
+        signed: new Date(),
+      })
+      .addDeviceKeyInfo({ deviceKey: publicKeyJWK })
+      .sign({
+        issuerPrivateKey,
+        issuerCertificate,
+        alg: 'ES256',
+      });
+    issuerMDoc = new MDoc([document]).encode();
+  }
+
+  // This is what the DEVICE does to generate a response:
+  {
+    deviceResponseMDoc = await DeviceResponse.from(issuerMDoc)
+      .usingPresentationDefinition(PRESENTATION_DEFINITION_1)
+      .usingSessionTranscriptBytes(sessionTranscriptBytes)
       .authenticateWithSignature(devicePrivateKey, 'ES256')
       .sign();
   }

--- a/README.md
+++ b/README.md
@@ -92,16 +92,21 @@ import fs from "node:fs";
 
 ## Generating a device response
 
-### Using a OID4VP handover
-
 ```js
-import { DeviceResponse } from "@auth0/mdl";
-(() => {
+import { DeviceResponse, DataItem, MDoc, DataItem, cborEncode} from '@auth0/mdl';
+import { createHash } from 'node:crypto';
+
+(async () => {
   let issuerMDoc;
   let deviceResponseMDoc;
 
-  // This is what the MDL issuer does to generate a credential:
+  /**
+   * This is what the MDL issuer does to generate a credential:
+   */
   {
+    let issuerPrivateKey;
+    let issuerCertificate;
+    let devicePublicKey; // the public key for the device, as a JWK
     const document = await new Document('org.iso.18013.5.1.mDL')
       .addIssuerNameSpace('org.iso.18013.5.1', {
         family_name: 'Jones',
@@ -112,7 +117,7 @@ import { DeviceResponse } from "@auth0/mdl";
       .addValidityInfo({
         signed: new Date(),
       })
-      .addDeviceKeyInfo({ deviceKey: publicKeyJWK })
+      .addDeviceKeyInfo({ deviceKey: devicePublicKey })
       .sign({
         issuerPrivateKey,
         issuerCertificate,
@@ -121,53 +126,65 @@ import { DeviceResponse } from "@auth0/mdl";
     issuerMDoc = new MDoc([document]).encode();
   }
 
-  // This is what the DEVICE does to generate a response:
+  /**
+   * This is what the DEVICE does to generate a response...
+   */
   {
-    deviceResponseMDoc = await DeviceResponse.from(issuerMDoc)
-      .usingPresentationDefinition(PRESENTATION_DEFINITION_1)
-      .usingHandover([mdocGeneratedNonce, clientId, responseUri, verifierGeneratedNonce])
-      .authenticateWithSignature(devicePrivateKey, 'ES256')
-      .sign();
-  }
-})();
-```
+    let devicePrivateKey; // the private key for the device, as a JWK
+    let presentationDefinition = {
+      // the presentation definition we create a response for
+      id: 'family_name_only',
+      input_descriptors: [
+        {
+          id: 'org.iso.18013.5.1.mDL',
+          format: { mso_mdoc: { alg: ['EdDSA', 'ES256'] } },
+          constraints: {
+            limit_disclosure: 'required',
+            fields: [{
+                path: ["$['org.iso.18013.5.1']['family_name']"],
+                intent_to_retain: false,
+              }],
+          },
+        },
+      ],
+    };
 
-### Using an arbitrary session transcript
+    /** ... using a OID4VP handover: */
+    {
+      // Parameters coming from the OID4VP transaction
+      let mdocGeneratedNonce, clientId, responseUri, verifierGeneratedNonce;
 
-```js
-import { DeviceResponse } from "@auth0/mdl";
-(() => {
-  let issuerMDoc;
-  let deviceResponseMDoc;
+      deviceResponseMDoc = await DeviceResponse.from(issuerMDoc)
+        .usingPresentationDefinition(presentationDefinition)
+        .usingHandover([mdocGeneratedNonce, clientId, responseUri, verifierGeneratedNonce])
+        .authenticateWithSignature(devicePrivateKey, 'ES256')
+        .sign();
+    }
 
-  // This is what the MDL issuer does to generate a credential:
-  {
-    const document = await new Document('org.iso.18013.5.1.mDL')
-      .addIssuerNameSpace('org.iso.18013.5.1', {
-        family_name: 'Jones',
-        given_name: 'Ava',
-        birth_date: '2007-03-25',
-      })
-      .useDigestAlgorithm('SHA-256')
-      .addValidityInfo({
-        signed: new Date(),
-      })
-      .addDeviceKeyInfo({ deviceKey: publicKeyJWK })
-      .sign({
-        issuerPrivateKey,
-        issuerCertificate,
-        alg: 'ES256',
-      });
-    issuerMDoc = new MDoc([document]).encode();
-  }
+    /** ... OR ALTERNATIVELY using an "Annex A" transcript: */
+    {
+      let encodedReaderEngagement; // CBOR as received from the reader
+      let encodedDeviceEngagement; // CBOR as sent to the reader
+      let encodedReaderPublicKey;  // as found in the ReaderEngagement
 
-  // This is what the DEVICE does to generate a response:
-  {
-    deviceResponseMDoc = await DeviceResponse.from(issuerMDoc)
-      .usingPresentationDefinition(PRESENTATION_DEFINITION_1)
-      .usingSessionTranscriptBytes(sessionTranscriptBytes)
-      .authenticateWithSignature(devicePrivateKey, 'ES256')
-      .sign();
+      const engagementToApp = Buffer.from(
+        createHash('sha256').update(encodedReaderEngagement).digest('hex'),
+        'hex',
+      );
+      const sessionTranscriptBytes = cborEncode(
+        DataItem.fromData([
+          new DataItem({ buffer: encodedDeviceEngagement }),
+          new DataItem({ buffer: encodedReaderPublicKey }),
+          engagementToApp,
+        ]),
+      );
+
+      deviceResponseMDoc = await DeviceResponse.from(issuerMDoc)
+        .usingPresentationDefinition(presentationDefinition)
+        .usingSessionTranscriptBytes(sessionTranscriptBytes)
+        .authenticateWithSignature(devicePrivateKey, 'ES256')
+        .sign();
+    }
   }
 })();
 ```

--- a/__tests__/diagnostic.tests.ts
+++ b/__tests__/diagnostic.tests.ts
@@ -1,6 +1,6 @@
 import { hex } from 'buffer-tag';
 import { Verifier } from '../src/index';
-import { DiagnosticInformation } from '../src/deviceResponse/types';
+import { DiagnosticInformation } from '../src/mdoc/model/types';
 
 export const ISSUER_CERTIFICATE = `-----BEGIN CERTIFICATE-----
 MIICKjCCAdCgAwIBAgIUV8bM0wi95D7KN0TyqHE42ru4hOgwCgYIKoZIzj0EAwIw

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,10 +2,8 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  globals: {
-    'ts-jest': {
-      isolatedModules: true,
-    },
+  transform: {
+    '.*/__tests__/.*/.*\\.tests\\.ts': ['ts-jest', {isolatedModules: true}]
   },
   testMatch: ['**/__tests__/**/*.tests.ts'],
 };

--- a/src/mdoc/model/DeviceResponse.ts
+++ b/src/mdoc/model/DeviceResponse.ts
@@ -73,7 +73,10 @@ export class DeviceResponse {
    * @returns {DeviceResponse}
    */
   public usingHandover(handover: string[]): DeviceResponse {
-    this.usingSessionTranscriptBytes(cborEncode(DataItem.fromData([null, null, handover])));
+    this.usingSessionTranscriptBytes(cborEncode(DataItem.fromData([
+      null, // deviceEngagementBytes
+      null, // eReaderKeyBytes
+      handover])));
     return this;
   }
 

--- a/src/mdoc/model/DeviceResponse.ts
+++ b/src/mdoc/model/DeviceResponse.ts
@@ -18,7 +18,7 @@ import COSEKeyToRAW from '../../cose/coseKey';
 export class DeviceResponse {
   private mdoc: MDoc;
   private pd: PresentationDefinition;
-  private handover: string[];
+  private sessionTranscriptBytes: Buffer;
   private useMac = true;
   private devicePrivateKey: Uint8Array;
   public deviceResponseCbor: Buffer;
@@ -65,13 +65,30 @@ export class DeviceResponse {
   }
 
   /**
-   * Set the handover data to use for the device response.
+   * Set the session transcript data to use for the device response with the given handover data.
+   * this is a shortcut to calling `usingSessionTranscriptBytes(<cbor encoding of [null, null, handover] in a Tagged 24 structure>)`,
+   * which is what the OID4VP protocol expects.
    *
-   * @param {string[]} handover - The handover data to use for the device response.
+   * @param {string[]} handover - The handover data to use in the session transcript.
    * @returns {DeviceResponse}
    */
   public usingHandover(handover: string[]): DeviceResponse {
-    this.handover = handover;
+    this.usingSessionTranscriptBytes(cborEncode(DataItem.fromData([null, null, handover])));
+    return this;
+  }
+
+  /**
+   * Set the session transcript data to use for the device response. This is arbitrary and should match
+   * the session transcript as it will be calculated by the verifier.
+   * We expect a buffer of bytes, as defined in as defined in ISO/IEC 18013-7 in both Annex A (Web API) and Annex B (OID4VP)
+   * @param {Buffer} sessionTranscriptBytes - The sessionTranscriptBytes data to use in the session transcript.
+   * @returns {DeviceResponse}
+   */
+  public usingSessionTranscriptBytes(sessionTranscriptBytes: Buffer): DeviceResponse {
+    if (this.sessionTranscriptBytes) {
+      throw new Error('A session transcript has already been set, either with .usingHandover or .usingSessionTranscriptBytes');
+    }
+    this.sessionTranscriptBytes = sessionTranscriptBytes;
     return this;
   }
 
@@ -139,7 +156,7 @@ export class DeviceResponse {
    */
   public async sign(): Promise<MDoc> {
     if (!this.pd) throw new Error('Must provide a presentation definition with .usingPresentationDefinition()');
-    if (!this.handover) throw new Error('Must provide handover data with .usingHandover()');
+    if (!this.sessionTranscriptBytes) throw new Error('Must provide the session transcript with .usingHandover() or .usingSessionTranscriptBytes()');
 
     const docs = await Promise.all(this.pd.input_descriptors.map((id) => this.handleInputDescriptor(id)));
     return new MDoc(docs);
@@ -165,14 +182,8 @@ export class DeviceResponse {
   }
 
   private async getDeviceSigned(docType: string): Promise<DeviceSigned> {
-    const sessionTranscript = [
-      null, // deviceEngagementBytes
-      null, // eReaderKeyBytes,
-      this.handover,
-    ];
-
     const deviceAuthenticationBytes = calculateDeviceAutenticationBytes(
-      sessionTranscript,
+      this.sessionTranscriptBytes,
       docType,
       this.nameSpaces,
     );
@@ -180,7 +191,7 @@ export class DeviceResponse {
     const deviceSigned: DeviceSigned = {
       nameSpaces: this.nameSpaces,
       deviceAuth: this.useMac
-        ? await this.getDeviceAuthMac(deviceAuthenticationBytes, sessionTranscript)
+        ? await this.getDeviceAuthMac(deviceAuthenticationBytes, this.sessionTranscriptBytes)
         : await this.getDeviceAuthSign(deviceAuthenticationBytes),
     };
 
@@ -189,7 +200,7 @@ export class DeviceResponse {
 
   private async getDeviceAuthMac(
     deviceAuthenticationBytes: Uint8Array,
-    sessionTranscript: any,
+    sessionTranscriptBytes: any,
   ): Promise<DeviceAuth> {
     const key = COSEKeyToRAW(this.devicePrivateKey);
     const { kid } = COSEKeyToJWK(this.devicePrivateKey);
@@ -197,7 +208,7 @@ export class DeviceResponse {
     const ephemeralMacKey = await calculateEphemeralMacKey(
       key,
       this.ephemeralPublicKey,
-      cborEncode(DataItem.fromData(sessionTranscript)),
+      sessionTranscriptBytes,
     );
 
     const mac = await Mac0.create(


### PR DESCRIPTION
As per ISO-18013-7, Session transcripts differ from Annex A to Annex B:
* Annex A uses the device engagement, the device keys and a handover based on the reader engagement
* Annex B uses OID-specific information: clientID, verifier and client nonces, response URI
The specification also states that the handover can be *anything else* if the session is mounted by other means.

Furthermore: the wallet as well as the verifier probably have an encoded session transcript at hand, since it is an important piece of information to securely exchange other secrets.

This PR opens the possibility to directly provide the session script in its encoded form, so that this library only concern itself with using these bits for verification.  
This is done with the new `DeviceResponse.usingSessionTranscriptBytes` method.

The only strong requirement is that whatever is given to this new method, is a CBOR encoding of a Tagged data item, with tag `24`.  
The specifications further describe that the value in said data item be a CBOR encoding of a 3 items array. This library does not enforce this requirement, so that users can decide more freely on what to use as a session transcript.

