### PR TITLE
fix: issuing_jurisdiction enforcement

### DIFF
--- a/src/mdoc/IssuerSignedItem.ts
+++ b/src/mdoc/IssuerSignedItem.ts
@@ -85,7 +85,7 @@ export class IssuerSignedItem {
     if (this.elementIdentifier === 'issuing_country') {
       return countryName === this.elementValue;
     }
-    if (this.elementIdentifier === 'issuing_jurisdiction') {
+    if (this.elementIdentifier === 'issuing_jurisdiction' && stateOrProvince) {
       return stateOrProvince === this.elementValue;
     }
     return undefined;

--- a/src/mdoc/Verifier.ts
+++ b/src/mdoc/Verifier.ts
@@ -283,7 +283,7 @@ export class Verifier {
           });
 
           const invalidJurisdiction = verifications.filter((v) => v.ns === ns && v.ev.elementIdentifier === 'issuing_jurisdiction')
-            .find((v) => !v.isValid || !v.ev.matchCertificate(ns, issuerAuth));
+            .find((v) => !v.isValid || (issuerAuth.stateOrProvince && !v.ev.matchCertificate(ns, issuerAuth)));
 
           onCheck({
             status: invalidJurisdiction ? 'FAILED' : 'PASSED',


### PR DESCRIPTION
According to the spec, this is required only when the `stateOrProvinceName` element is present in the DS certificate.

fixes #26