### PR TITLE
feat: wiring support for P-384 and P-521

### DIFF
--- a/__tests__/issuing/deviceResponseWithMac.tests.ts
+++ b/__tests__/issuing/deviceResponseWithMac.tests.ts
@@ -11,7 +11,6 @@ import {
 } from '../../src';
 import { ISSUER_CERTIFICATE, ISSUER_PRIVATE_KEY_JWK, PRESENTATION_DEFINITION_1 } from './config';
 import { DataItem, cborEncode } from '../../src/cbor';
-import COSEKeyToRAW from '../../src/cose/coseKey';
 
 const curves = [
   { name: 'P-256', alg: 'ECDH-ES', opts: { crv: 'P-256' } },
@@ -96,8 +95,8 @@ curves.forEach((c) => {
         const readerKeypair = await jose.generateKeyPair(c.alg, c.opts);
         const readerKey = await jose.exportJWK(readerKeypair.privateKey);
         const { d: _1, ...pubKey } = readerKey;
-        readerPrivateKey = COSEKeyToRAW(COSEKeyFromJWK(readerKey)); // only d
-        readerPublicKey = COSEKeyToRAW(COSEKeyFromJWK(pubKey)); // 0x04 || x || y
+        readerPrivateKey = COSEKeyFromJWK(readerKey);
+        readerPublicKey = COSEKeyFromJWK(pubKey);
       }
     });
 

--- a/__tests__/issuing/deviceResponseWithMac.tests.ts
+++ b/__tests__/issuing/deviceResponseWithMac.tests.ts
@@ -9,250 +9,257 @@ import {
   DeviceResponse,
   DeviceSignedDocument,
 } from '../../src';
-import { DEVICE_JWK, ISSUER_CERTIFICATE, ISSUER_PRIVATE_KEY_JWK, PRESENTATION_DEFINITION_1 } from './config';
+import { ISSUER_CERTIFICATE, ISSUER_PRIVATE_KEY_JWK, PRESENTATION_DEFINITION_1 } from './config';
 import { DataItem, cborEncode } from '../../src/cbor';
 import COSEKeyToRAW from '../../src/cose/coseKey';
 
-const { d, ...publicKeyJWK } = DEVICE_JWK as jose.JWK;
+const curves = [
+  { name: 'P-256', alg: 'ECDH-ES', opts: { crv: 'P-256' } },
+  { name: 'P-384', alg: 'ECDH-ES', opts: { crv: 'P-384' } },
+  { name: 'P-521', alg: 'ECDH-ES', opts: { crv: 'P-521' } },
+];
 
-describe('issuing a device response with MAC authentication', () => {
-  let encoded: Uint8Array;
-  let parsedDocument: DeviceSignedDocument;
-  let mdoc: MDoc;
-  let ephemeralPrivateKey: Uint8Array;
-  let ephemeralPublicKey: Uint8Array;
+curves.forEach((c) => {
+  describe(`issuing a device response with MAC authentication (using ${c.name})`, () => {
+    let devicePrivateKey: jose.JWK;
+    let devicePublicJwk: jose.JWK;
+    let encoded: Uint8Array;
+    let parsedDocument: DeviceSignedDocument;
+    let mdoc: MDoc;
+    let readerPrivateKey: Uint8Array;
+    let readerPublicKey: Uint8Array;
 
-  const signed = new Date('2023-10-24T14:55:18Z');
-  const validUntil = new Date(signed);
-  validUntil.setFullYear(signed.getFullYear() + 30);
+    const signed = new Date('2023-10-24T14:55:18Z');
+    const validUntil = new Date(signed);
+    validUntil.setFullYear(signed.getFullYear() + 30);
 
-  beforeAll(async () => {
-    const issuerPrivateKey = ISSUER_PRIVATE_KEY_JWK;
+    beforeAll(async () => {
+      // This is the device setup
+      {
+        const keypair = await jose.generateKeyPair(c.alg, c.opts);
+        devicePrivateKey = await jose.exportJWK(keypair.privateKey);
+        const { d, ...pk } = devicePrivateKey;
+        devicePublicJwk = pk;
+      }
 
-    // this is the ISSUER side
-    {
-      const document = await new Document('org.iso.18013.5.1.mDL')
-        .addIssuerNameSpace('org.iso.18013.5.1', {
-          family_name: 'Jones',
-          given_name: 'Ava',
-          birth_date: '2007-03-25',
-          issue_date: '2023-09-01',
-          expiry_date: '2028-09-30',
-          issuing_country: 'US',
-          issuing_authority: 'NY DMV',
-          document_number: '01-856-5050',
-          portrait: 'bstr',
-          driving_privileges: [
-            {
-              vehicle_category_code: 'C',
-              issue_date: '2022-09-01',
-              expiry_date: '2027-09-30',
-            },
-          ],
-          un_distinguishing_sign: 'tbd-us.ny.dmv',
+      // this is the ISSUER side
+      {
+        const issuerPrivateKey = ISSUER_PRIVATE_KEY_JWK;
+        const document = await new Document('org.iso.18013.5.1.mDL')
+          .addIssuerNameSpace('org.iso.18013.5.1', {
+            family_name: 'Jones',
+            given_name: 'Ava',
+            birth_date: '2007-03-25',
+            issue_date: '2023-09-01',
+            expiry_date: '2028-09-30',
+            issuing_country: 'US',
+            issuing_authority: 'NY DMV',
+            document_number: '01-856-5050',
+            portrait: 'bstr',
+            driving_privileges: [
+              {
+                vehicle_category_code: 'C',
+                issue_date: '2022-09-01',
+                expiry_date: '2027-09-30',
+              },
+            ],
+            un_distinguishing_sign: 'tbd-us.ny.dmv',
+            sex: 'F',
+            height: '5\' 8"',
+            weight: '120lb',
+            eye_colour: 'brown',
+            hair_colour: 'brown',
+            resident_addres: '123 Street Rd',
+            resident_city: 'Brooklyn',
+            resident_state: 'NY',
+            resident_postal_code: '19001',
+            resident_country: 'US',
+            issuing_jurisdiction: 'New York',
+          })
+          .useDigestAlgorithm('SHA-512')
+          .addValidityInfo({
+            signed,
+            validUntil,
+          })
+          .addDeviceKeyInfo({ deviceKey: devicePublicJwk })
+          .sign({
+            issuerPrivateKey,
+            issuerCertificate: ISSUER_CERTIFICATE,
+            alg: 'ES256',
+          });
 
-          sex: 'F',
-          height: '5\' 8"',
-          weight: '120lb',
-          eye_colour: 'brown',
-          hair_colour: 'brown',
-          resident_addres: '123 Street Rd',
-          resident_city: 'Brooklyn',
-          resident_state: 'NY',
-          resident_postal_code: '19001',
-          resident_country: 'US',
-          issuing_jurisdiction: 'New York',
-        })
-        .useDigestAlgorithm('SHA-512')
-        .addValidityInfo({
-          signed,
-          validUntil,
-        })
-        .addDeviceKeyInfo({ deviceKey: publicKeyJWK })
-        .sign({
-          issuerPrivateKey,
-          issuerCertificate: ISSUER_CERTIFICATE,
-          alg: 'ES256',
-        });
-
-      mdoc = new MDoc([document]);
+        mdoc = new MDoc([document]);
+      }
 
       // This is the verifier side before requesting the Device Response
       {
-        const ephemeralKey = await jose.exportJWK((await jose.generateKeyPair('ES256')).privateKey);
-        const { d: _1, ...ephemeralKeyPublic } = ephemeralKey;
-        ephemeralPrivateKey = COSEKeyToRAW(COSEKeyFromJWK(ephemeralKey));
-        ephemeralPublicKey = COSEKeyToRAW(COSEKeyFromJWK(ephemeralKeyPublic));
+        const readerKeypair = await jose.generateKeyPair(c.alg, c.opts);
+        const readerKey = await jose.exportJWK(readerKeypair.privateKey);
+        const { d: _1, ...pubKey } = readerKey;
+        readerPrivateKey = COSEKeyToRAW(COSEKeyFromJWK(readerKey)); // only d
+        readerPublicKey = COSEKeyToRAW(COSEKeyFromJWK(pubKey)); // 0x04 || x || y
       }
-    }
-  });
-
-  describe('using OID4VP handover', () => {
-    const verifierGeneratedNonce = 'abcdefg';
-    const mdocGeneratedNonce = '123456';
-    const clientId = 'Cq1anPb8vZU5j5C0d7hcsbuJLBpIawUJIDQRi2Ebwb4';
-    const responseUri = 'http://localhost:4000/api/presentation_request/dc8999df-d6ea-4c84-9985-37a8b81a82ec/callback';
-
-    const getSessionTranscriptBytes = (clId: string, respUri: string, nonce: string, mdocNonce: string) => cborEncode(
-      DataItem.fromData([
-        null, // DeviceEngagementBytes
-        null, // EReaderKeyBytes
-        [mdocNonce, clId, respUri, nonce], // Handover = OID4VPHandover
-      ]),
-    );
-
-    beforeAll(async () => {
-      //  This is the Device side
-      const deviceResponseMDoc = await DeviceResponse.from(mdoc)
-        .usingPresentationDefinition(PRESENTATION_DEFINITION_1)
-        .usingSessionTranscriptForOID4VP(mdocGeneratedNonce, clientId, responseUri, verifierGeneratedNonce)
-        .authenticateWithMAC(DEVICE_JWK, ephemeralPublicKey, 'HS256')
-        .addDeviceNameSpace('com.foobar-device', { test: 1234 })
-        .sign();
-
-      encoded = deviceResponseMDoc.encode();
-      const parsedMDOC = parse(encoded);
-      [parsedDocument] = parsedMDOC.documents as DeviceSignedDocument[];
     });
 
-    it('should be verifiable', async () => {
-      const verifier = new Verifier([ISSUER_CERTIFICATE]);
-      await verifier.verify(encoded, {
-        ephemeralReaderKey: ephemeralPrivateKey,
-        encodedSessionTranscript: getSessionTranscriptBytes(clientId, responseUri, verifierGeneratedNonce, mdocGeneratedNonce),
-      });
-    });
+    describe('using OID4VP handover', () => {
+      const verifierGeneratedNonce = 'abcdefg';
+      const mdocGeneratedNonce = '123456';
+      const clientId = 'Cq1anPb8vZU5j5C0d7hcsbuJLBpIawUJIDQRi2Ebwb4';
+      const responseUri = 'http://localhost:4000/api/presentation_request/dc8999df-d6ea-4c84-9985-37a8b81a82ec/callback';
 
-    describe('should not be verifiable', () => {
-      [
-        ['clientId', { clientId: 'wrong', responseUri, verifierGeneratedNonce, mdocGeneratedNonce }] as const,
-        ['responseUri', { clientId, responseUri: 'wrong', verifierGeneratedNonce, mdocGeneratedNonce }] as const,
-        ['verifierGeneratedNonce', { clientId, responseUri, verifierGeneratedNonce: 'wrong', mdocGeneratedNonce }] as const,
-        ['mdocGeneratedNonce', { clientId, responseUri, verifierGeneratedNonce, mdocGeneratedNonce: 'wrong' }] as const,
-      ].forEach(([name, values]) => {
-        it(`with a different ${name}`, async () => {
-          try {
-            const verifier = new Verifier([ISSUER_CERTIFICATE]);
-            await verifier.verify(encoded, {
-              ephemeralReaderKey: ephemeralPrivateKey,
-              encodedSessionTranscript: getSessionTranscriptBytes(values.clientId, values.responseUri, values.verifierGeneratedNonce, values.mdocGeneratedNonce),
-            });
-            throw new Error('should not validate with different transcripts');
-          } catch (error) {
-            expect(error.message).toMatch('Unable to verify deviceAuth MAC: Device MAC must be valid');
-          }
-        });
-      });
-    });
+      const getSessionTranscriptBytes = (clId: string, respUri: string, nonce: string, mdocNonce: string) => cborEncode(
+        DataItem.fromData([
+          null, // DeviceEngagementBytes
+          null, // EReaderKeyBytes
+          [mdocNonce, clId, respUri, nonce], // Handover = OID4VPHandover
+        ]),
+      );
 
-    it('should generate a device mac without payload', () => {
-      expect(parsedDocument.deviceSigned.deviceAuth.deviceMac?.payload).toBeNull();
-    });
-
-    it('should contain the validity info', () => {
-      const { validityInfo } = parsedDocument.issuerSigned.issuerAuth.decodedPayload;
-      expect(validityInfo).toBeDefined();
-      expect(validityInfo.signed).toEqual(signed);
-      expect(validityInfo.validFrom).toEqual(signed);
-      expect(validityInfo.validUntil).toEqual(validUntil);
-      expect(validityInfo.expectedUpdate).toBeUndefined();
-    });
-
-    it('should contain the device namespaces', () => {
-      expect(parsedDocument.getDeviceNameSpace('com.foobar-device'))
-        .toEqual({ test: 1234 });
-    });
-  });
-
-  describe('using WebAPI handover', () => {
-    // The actual value for the engagements & the key do not matter,
-    // as long as the device and the reader agree on what value to use.
-    const eReaderKeyBytes: Buffer = randomFillSync(Buffer.alloc(32));
-    const readerEngagementBytes = randomFillSync(Buffer.alloc(32));
-    const deviceEngagementBytes = randomFillSync(Buffer.alloc(32));
-
-    const getSessionTranscriptBytes = (
-      rdrEngtBytes: Buffer,
-      devEngtBytes: Buffer,
-      eRdrKeyBytes: Buffer,
-    ) => cborEncode(
-      DataItem.fromData([
-        new DataItem({ buffer: devEngtBytes }),
-        new DataItem({ buffer: eRdrKeyBytes }),
-        rdrEngtBytes,
-      ]),
-    );
-
-    beforeAll(async () => {
-      // This is the verifier side before requesting the Device Response
-      {
-        const ephemeralKey = await jose.exportJWK((await jose.generateKeyPair('ES256')).privateKey);
-        ephemeralPrivateKey = COSEKeyToRAW(COSEKeyFromJWK(ephemeralKey));
-        const { d: _1, ...ephemeralKeyPublic } = ephemeralKey;
-        ephemeralPublicKey = COSEKeyToRAW(COSEKeyFromJWK(ephemeralKeyPublic));
-      }
-
-      //  This is the Device side
-      {
+      beforeAll(async () => {
+        //  This is the Device side
         const deviceResponseMDoc = await DeviceResponse.from(mdoc)
           .usingPresentationDefinition(PRESENTATION_DEFINITION_1)
-          .usingSessionTranscriptForWebAPI(deviceEngagementBytes, readerEngagementBytes, eReaderKeyBytes)
-          .authenticateWithMAC(DEVICE_JWK, ephemeralPublicKey, 'HS256')
+          .usingSessionTranscriptForOID4VP(mdocGeneratedNonce, clientId, responseUri, verifierGeneratedNonce)
+          .authenticateWithMAC(devicePrivateKey, readerPublicKey, 'HS256')
           .addDeviceNameSpace('com.foobar-device', { test: 1234 })
           .sign();
+
         encoded = deviceResponseMDoc.encode();
-      }
-
-      const parsedMDOC = parse(encoded);
-      [parsedDocument] = parsedMDOC.documents as DeviceSignedDocument[];
-    });
-
-    it('should be verifiable', async () => {
-      const verifier = new Verifier([ISSUER_CERTIFICATE]);
-      await verifier.verify(encoded, {
-        ephemeralReaderKey: ephemeralPrivateKey,
-        encodedSessionTranscript: getSessionTranscriptBytes(readerEngagementBytes, deviceEngagementBytes, eReaderKeyBytes),
+        const parsedMDOC = parse(encoded);
+        [parsedDocument] = parsedMDOC.documents as DeviceSignedDocument[];
       });
-    });
 
-    describe('should not be verifiable', () => {
-      const wrong = randomFillSync(Buffer.alloc(32));
-      [
-        ['readerEngagementBytes', { readerEngagementBytes: wrong, deviceEngagementBytes, eReaderKeyBytes }] as const,
-        ['deviceEngagementBytes', { readerEngagementBytes, deviceEngagementBytes: wrong, eReaderKeyBytes }] as const,
-        ['eReaderKeyBytes', { readerEngagementBytes, deviceEngagementBytes, eReaderKeyBytes: wrong }] as const,
-      ].forEach(([name, values]) => {
-        it(`with a different ${name}`, async () => {
-          const verifier = new Verifier([ISSUER_CERTIFICATE]);
-          try {
-            await verifier.verify(encoded, {
-              ephemeralReaderKey: ephemeralPrivateKey,
-              encodedSessionTranscript: getSessionTranscriptBytes(values.readerEngagementBytes, values.deviceEngagementBytes, values.eReaderKeyBytes),
-            });
-            throw new Error('should not validate with different transcripts');
-          } catch (error) {
-            expect(error.message).toMatch('Unable to verify deviceAuth MAC: Device MAC must be valid');
-          }
+      it('should be verifiable', async () => {
+        const verifier = new Verifier([ISSUER_CERTIFICATE]);
+        await verifier.verify(encoded, {
+          ephemeralReaderKey: readerPrivateKey,
+          encodedSessionTranscript: getSessionTranscriptBytes(clientId, responseUri, verifierGeneratedNonce, mdocGeneratedNonce),
         });
       });
+
+      describe('should not be verifiable', () => {
+        [
+          ['clientId', { clientId: 'wrong', responseUri, verifierGeneratedNonce, mdocGeneratedNonce }] as const,
+          ['responseUri', { clientId, responseUri: 'wrong', verifierGeneratedNonce, mdocGeneratedNonce }] as const,
+          ['verifierGeneratedNonce', { clientId, responseUri, verifierGeneratedNonce: 'wrong', mdocGeneratedNonce }] as const,
+          ['mdocGeneratedNonce', { clientId, responseUri, verifierGeneratedNonce, mdocGeneratedNonce: 'wrong' }] as const,
+        ].forEach(([name, values]) => {
+          it(`with a different ${name}`, async () => {
+            try {
+              const verifier = new Verifier([ISSUER_CERTIFICATE]);
+              await verifier.verify(encoded, {
+                ephemeralReaderKey: readerPrivateKey,
+                encodedSessionTranscript: getSessionTranscriptBytes(values.clientId, values.responseUri, values.verifierGeneratedNonce, values.mdocGeneratedNonce),
+              });
+              throw new Error('should not validate with different transcripts');
+            } catch (error) {
+              expect(error.message).toMatch('Unable to verify deviceAuth MAC: Device MAC must be valid');
+            }
+          });
+        });
+      });
+
+      it('should generate a device mac without payload', () => {
+        expect(parsedDocument.deviceSigned.deviceAuth.deviceMac?.payload).toBeNull();
+      });
+
+      it('should contain the validity info', () => {
+        const { validityInfo } = parsedDocument.issuerSigned.issuerAuth.decodedPayload;
+        expect(validityInfo).toBeDefined();
+        expect(validityInfo.signed).toEqual(signed);
+        expect(validityInfo.validFrom).toEqual(signed);
+        expect(validityInfo.validUntil).toEqual(validUntil);
+        expect(validityInfo.expectedUpdate).toBeUndefined();
+      });
+
+      it('should contain the device namespaces', () => {
+        expect(parsedDocument.getDeviceNameSpace('com.foobar-device'))
+          .toEqual({ test: 1234 });
+      });
     });
 
-    it('should generate a device mac without payload', () => {
-      expect(parsedDocument.deviceSigned.deviceAuth.deviceMac?.payload).toBeNull();
-    });
+    describe('using WebAPI handover', () => {
+      // The actual value for the engagements & the key do not matter,
+      // as long as the device and the reader agree on what value to use.
+      const eReaderKeyBytes: Buffer = randomFillSync(Buffer.alloc(32));
+      const readerEngagementBytes = randomFillSync(Buffer.alloc(32));
+      const deviceEngagementBytes = randomFillSync(Buffer.alloc(32));
 
-    it('should contain the validity info', () => {
-      const { validityInfo } = parsedDocument.issuerSigned.issuerAuth.decodedPayload;
-      expect(validityInfo).toBeDefined();
-      expect(validityInfo.signed).toEqual(signed);
-      expect(validityInfo.validFrom).toEqual(signed);
-      expect(validityInfo.validUntil).toEqual(validUntil);
-      expect(validityInfo.expectedUpdate).toBeUndefined();
-    });
+      const getSessionTranscriptBytes = (
+        rdrEngtBytes: Buffer,
+        devEngtBytes: Buffer,
+        eRdrKeyBytes: Buffer,
+      ) => cborEncode(
+        DataItem.fromData([
+          new DataItem({ buffer: devEngtBytes }),
+          new DataItem({ buffer: eRdrKeyBytes }),
+          rdrEngtBytes,
+        ]),
+      );
 
-    it('should contain the device namespaces', () => {
-      expect(parsedDocument.getDeviceNameSpace('com.foobar-device'))
-        .toEqual({ test: 1234 });
+      beforeAll(async () => {
+        //  This is the Device side
+        {
+          const deviceResponseMDoc = await DeviceResponse.from(mdoc)
+            .usingPresentationDefinition(PRESENTATION_DEFINITION_1)
+            .usingSessionTranscriptForWebAPI(deviceEngagementBytes, readerEngagementBytes, eReaderKeyBytes)
+            .authenticateWithMAC(devicePrivateKey, readerPublicKey, 'HS256')
+            .addDeviceNameSpace('com.foobar-device', { test: 1234 })
+            .sign();
+          encoded = deviceResponseMDoc.encode();
+        }
+
+        const parsedMDOC = parse(encoded);
+        [parsedDocument] = parsedMDOC.documents as DeviceSignedDocument[];
+      });
+
+      it('should be verifiable', async () => {
+        const verifier = new Verifier([ISSUER_CERTIFICATE]);
+        await verifier.verify(encoded, {
+          ephemeralReaderKey: readerPrivateKey,
+          encodedSessionTranscript: getSessionTranscriptBytes(readerEngagementBytes, deviceEngagementBytes, eReaderKeyBytes),
+        });
+      });
+
+      describe('should not be verifiable', () => {
+        const wrong = randomFillSync(Buffer.alloc(32));
+        [
+          ['readerEngagementBytes', { readerEngagementBytes: wrong, deviceEngagementBytes, eReaderKeyBytes }] as const,
+          ['deviceEngagementBytes', { readerEngagementBytes, deviceEngagementBytes: wrong, eReaderKeyBytes }] as const,
+          ['eReaderKeyBytes', { readerEngagementBytes, deviceEngagementBytes, eReaderKeyBytes: wrong }] as const,
+        ].forEach(([name, values]) => {
+          it(`with a different ${name}`, async () => {
+            const verifier = new Verifier([ISSUER_CERTIFICATE]);
+            try {
+              await verifier.verify(encoded, {
+                ephemeralReaderKey: readerPrivateKey,
+                encodedSessionTranscript: getSessionTranscriptBytes(values.readerEngagementBytes, values.deviceEngagementBytes, values.eReaderKeyBytes),
+              });
+              throw new Error('should not validate with different transcripts');
+            } catch (error) {
+              expect(error.message).toMatch('Unable to verify deviceAuth MAC: Device MAC must be valid');
+            }
+          });
+        });
+      });
+
+      it('should generate a device mac without payload', () => {
+        expect(parsedDocument.deviceSigned.deviceAuth.deviceMac?.payload).toBeNull();
+      });
+
+      it('should contain the validity info', () => {
+        const { validityInfo } = parsedDocument.issuerSigned.issuerAuth.decodedPayload;
+        expect(validityInfo).toBeDefined();
+        expect(validityInfo.signed).toEqual(signed);
+        expect(validityInfo.validFrom).toEqual(signed);
+        expect(validityInfo.validUntil).toEqual(validUntil);
+        expect(validityInfo.expectedUpdate).toBeUndefined();
+      });
+
+      it('should contain the device namespaces', () => {
+        expect(parsedDocument.getDeviceNameSpace('com.foobar-device'))
+          .toEqual({ test: 1234 });
+      });
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@auth0/mdl",
-  "version": "0.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@auth0/mdl",
-      "version": "0.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.2.0",

--- a/src/mdoc/Verifier.ts
+++ b/src/mdoc/Verifier.ts
@@ -20,7 +20,6 @@ import { parse } from './parser';
 import IssuerAuth from './model/IssuerAuth';
 import { IssuerSignedDocument } from './model/IssuerSignedDocument';
 import { DeviceSignedDocument } from './model/DeviceSignedDocument';
-import { cborEncode } from '../cbor';
 
 const MDL_NAMESPACE = 'org.iso.18013.5.1';
 
@@ -197,7 +196,7 @@ export class Verifier {
     try {
       const ephemeralMacKey = await calculateEphemeralMacKey(
         options.ephemeralPrivateKey,
-        cborEncode(deviceKeyCoseKey),
+        deviceKeyCoseKey,
         options.sessionTranscriptBytes,
       );
 

--- a/src/mdoc/Verifier.ts
+++ b/src/mdoc/Verifier.ts
@@ -20,7 +20,7 @@ import { parse } from './parser';
 import IssuerAuth from './model/IssuerAuth';
 import { IssuerSignedDocument } from './model/IssuerSignedDocument';
 import { DeviceSignedDocument } from './model/DeviceSignedDocument';
-import COSEKeyToRAW from '../cose/coseKey';
+import { cborEncode } from '../cbor';
 
 const MDL_NAMESPACE = 'org.iso.18013.5.1';
 
@@ -195,14 +195,10 @@ export class Verifier {
     if (!options.ephemeralPrivateKey) { return; }
 
     try {
-      const deviceKeyRaw = COSEKeyToRAW(deviceKeyCoseKey);
-      const { kty, crv } = COSEKeyToJWK(deviceKeyCoseKey);
       const ephemeralMacKey = await calculateEphemeralMacKey(
         options.ephemeralPrivateKey,
-        deviceKeyRaw,
+        cborEncode(deviceKeyCoseKey),
         options.sessionTranscriptBytes,
-        kty,
-        crv,
       );
 
       const isValid = await deviceAuth.deviceMac.verify(

--- a/src/mdoc/Verifier.ts
+++ b/src/mdoc/Verifier.ts
@@ -196,10 +196,13 @@ export class Verifier {
 
     try {
       const deviceKeyRaw = COSEKeyToRAW(deviceKeyCoseKey);
+      const { kty, crv } = COSEKeyToJWK(deviceKeyCoseKey);
       const ephemeralMacKey = await calculateEphemeralMacKey(
         options.ephemeralPrivateKey,
         deviceKeyRaw,
         options.sessionTranscriptBytes,
+        kty,
+        crv,
       );
 
       const isValid = await deviceAuth.deviceMac.verify(

--- a/src/mdoc/model/DeviceResponse.ts
+++ b/src/mdoc/model/DeviceResponse.ts
@@ -270,15 +270,12 @@ export class DeviceResponse {
     deviceAuthenticationBytes: Uint8Array,
     sessionTranscriptBytes: any,
   ): Promise<DeviceAuth> {
-    const key = COSEKeyToRAW(this.devicePrivateKey);
-    const { kid, kty, crv } = COSEKeyToJWK(this.devicePrivateKey);
+    const { kid } = COSEKeyToJWK(this.devicePrivateKey);
 
     const ephemeralMacKey = await calculateEphemeralMacKey(
-      key,
+      this.devicePrivateKey,
       this.ephemeralPublicKey,
       sessionTranscriptBytes,
-      kty,
-      crv,
     );
 
     const mac = await Mac0.create(

--- a/src/mdoc/model/DeviceResponse.ts
+++ b/src/mdoc/model/DeviceResponse.ts
@@ -271,12 +271,14 @@ export class DeviceResponse {
     sessionTranscriptBytes: any,
   ): Promise<DeviceAuth> {
     const key = COSEKeyToRAW(this.devicePrivateKey);
-    const { kid } = COSEKeyToJWK(this.devicePrivateKey);
+    const { kid, kty, crv } = COSEKeyToJWK(this.devicePrivateKey);
 
     const ephemeralMacKey = await calculateEphemeralMacKey(
       key,
       this.ephemeralPublicKey,
       sessionTranscriptBytes,
+      kty,
+      crv,
     );
 
     const mac = await Mac0.create(

--- a/src/mdoc/utils.ts
+++ b/src/mdoc/utils.ts
@@ -1,5 +1,7 @@
 import * as pkijs from 'pkijs';
 import { p256 } from '@noble/curves/p256';
+import { p384 } from '@noble/curves/p384';
+import { p521 } from '@noble/curves/p521';
 import * as webcrypto from 'uncrypto';
 import { Buffer } from 'buffer';
 import hkdf from '@panva/hkdf';
@@ -44,12 +46,41 @@ export const calculateEphemeralMacKey = async (
   privateKey: Uint8Array,
   publicKey: Uint8Array,
   sessionTranscriptBytes: Uint8Array,
+  kty = 'EC',
+  crv = 'P-256',
 ): Promise<Uint8Array> => {
-  const ikm = p256.getSharedSecret(
-    Buffer.from(privateKey).toString('hex'),
-    Buffer.from(publicKey).toString('hex'),
-    true,
-  ).slice(1);
+  let ikm;
+  if ((kty === 'EC')) {
+    if (crv === 'P-256') {
+      ikm = p256
+        .getSharedSecret(
+          Buffer.from(privateKey).toString('hex'),
+          Buffer.from(publicKey).toString('hex'),
+          true,
+        )
+        .slice(1);
+    } else if (crv === 'P-384') {
+      ikm = p384
+        .getSharedSecret(
+          Buffer.from(privateKey).toString('hex'),
+          Buffer.from(publicKey).toString('hex'),
+          true,
+        )
+        .slice(1);
+    } else if (crv === 'P-521') {
+      ikm = p521
+        .getSharedSecret(
+          Buffer.from(privateKey).toString('hex'),
+          Buffer.from(publicKey).toString('hex'),
+          true,
+        )
+        .slice(1);
+    } else {
+      throw new Error(`unsupported EC curve: ${crv}`);
+    }
+  } else {
+    throw new Error(`unsupported key type: ${kty}`);
+  }
   const salt = new Uint8Array(await subtle.digest('SHA-256', sessionTranscriptBytes));
   const info = Buffer.from('EMacKey', 'utf-8');
   const result = await hkdf('sha256', ikm, salt, info, 32);

--- a/src/mdoc/utils.ts
+++ b/src/mdoc/utils.ts
@@ -45,8 +45,8 @@ export const hmacSHA256 = async (
  * @returns {Uint8Array} - The ephemeral mac key
  */
 export const calculateEphemeralMacKey = async (
-  privateKey: Uint8Array,
-  publicKey: Uint8Array,
+  privateKey: Uint8Array | Map<number, Uint8Array | number>,
+  publicKey: Uint8Array | Map<number, Uint8Array | number>,
   sessionTranscriptBytes: Uint8Array,
 ): Promise<Uint8Array> => {
   const { kty, crv } = COSEKeyToJWK(privateKey);


### PR DESCRIPTION
Adding the possibility to compute MAC authentications with other NIST elliptic curves.

The curve used is chosen to be the one the private key is defined on:  
When calculating the MAC, this is the device private key.  
When verifying it, this is the reader private key.