### PR TITLE
fix: when `birth_date` is present, include `age_over_NN` only for `org.iso.18013.5.1` namespace

### DIFF
--- a/src/mdoc/model/Document.ts
+++ b/src/mdoc/model/Document.ts
@@ -89,7 +89,8 @@ export class Document {
 
     for (const [key, value] of Object.entries(values)) {
       addAttribute(key, value);
-      if (key === 'birth_date') {
+
+      if (key === 'birth_date' && namespace === DEFAULT_NS) {
         const ageInYears = getAgeInYears(value);
         addAttribute('age_over_21', ageInYears >= 21);
         addAttribute(`age_over_${Math.floor(ageInYears)}`, true);


### PR DESCRIPTION
closes #32 