### PR TITLE
fix(issuance): stop including `age_over_{age}` and `age_over_21` when `birth_date` is set

### DIFF
--- a/__tests__/example/example5.tests.ts
+++ b/__tests__/example/example5.tests.ts
@@ -70,7 +70,7 @@ describe('example 5: device response contains a partial x5chain of the issuer ce
 
     expect(diagnosticInfo.issuerSignature).toEqual({
       alg: 'EdDSA',
-      digests: { 'org.iso.18013.5.1': 5 },
+      digests: { 'org.iso.18013.5.1': 3 },
       isValid: true,
       reasons: [],
     });

--- a/__tests__/issuing/issuingMDoc.tests.ts
+++ b/__tests__/issuing/issuingMDoc.tests.ts
@@ -104,12 +104,8 @@ describe('issuing an MDOC', () => {
 
   it('should include the namespace and attributes', () => {
     const attrValues = parsedDocument.getIssuerNameSpace('org.iso.18013.5.1');
-    // @ts-ignore
-    const currentAge = new Date(Date.now() - new Date('2007-03-25')).getFullYear() - 1970;
     expect(attrValues).toMatchInlineSnapshot(`
 {
-  "age_over_${currentAge}": true,
-  "age_over_21": ${currentAge >= 21},
   "birth_date": "2007-03-25",
   "document_number": "01-856-5050",
   "driving_privileges": [

--- a/src/mdoc/model/Document.ts
+++ b/src/mdoc/model/Document.ts
@@ -9,15 +9,6 @@ import { IssuerSignedDocument } from './IssuerSignedDocument';
 
 const DEFAULT_NS = 'org.iso.18013.5.1';
 
-const getAgeInYears = (birth: string): number => {
-  const birthDate = new Date(birth);
-  birthDate.setHours(0, 0, 0, 0);
-  // @ts-ignore
-  const ageDifMs = Date.now() - birthDate;
-  const ageDate = new Date(ageDifMs);
-  return Math.abs(ageDate.getUTCFullYear() - 1970);
-};
-
 const addYears = (date: Date, years: number): Date => {
   const r = new Date(date.getTime());
   r.setFullYear(date.getFullYear() + years);
@@ -89,12 +80,6 @@ export class Document {
 
     for (const [key, value] of Object.entries(values)) {
       addAttribute(key, value);
-
-      if (key === 'birth_date' && namespace === DEFAULT_NS) {
-        const ageInYears = getAgeInYears(value);
-        addAttribute('age_over_21', ageInYears >= 21);
-        addAttribute(`age_over_${Math.floor(ageInYears)}`, true);
-      }
     }
 
     return this;


### PR DESCRIPTION
fixes #39 