### PR TITLE
chore: export MDLError and MDLParseError from mdoc/errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,4 @@ export { Document } from './mdoc/model/Document';
 export { IssuerSignedDocument } from './mdoc/model/IssuerSignedDocument';
 export { DeviceSignedDocument } from './mdoc/model/DeviceSignedDocument';
 export { DeviceResponse } from './mdoc/model/DeviceResponse';
+export { MDLError, MDLParseError } from './mdoc/errors'


### PR DESCRIPTION
First step into #45 probably should be this. 

For the time being developers can use this error class to check if the error thrown is expected or an unexpected runtime error. Also reading the `message` might be bit easier once the type it is known.