### PR TITLE
feat: provide a `VerificationAssessment.id` value for each verification check

### DIFF
--- a/__tests__/verifier.tests.ts
+++ b/__tests__/verifier.tests.ts
@@ -31,8 +31,11 @@ describe('verifier', () => {
           ephemeralReaderKey,
           encodedSessionTranscript,
           onCheck: (verification) => {
-            if (verification.check.includes('Issuer certificate must be valid') &&
-              verification.status === 'FAILED') {
+            if (
+              verification.id === 'ISSUER_CERTIFICATE_VALIDITY' &&
+              verification.check.includes('Issuer certificate must be valid') &&
+              verification.status === 'FAILED'
+            ) {
               called = true;
             }
           },

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,4 +7,4 @@ export { Document } from './mdoc/model/Document';
 export { IssuerSignedDocument } from './mdoc/model/IssuerSignedDocument';
 export { DeviceSignedDocument } from './mdoc/model/DeviceSignedDocument';
 export { DeviceResponse } from './mdoc/model/DeviceResponse';
-export { MDLError, MDLParseError } from './mdoc/errors'
+export { MDLError, MDLParseError } from './mdoc/errors';

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@ export { IssuerSignedDocument } from './mdoc/model/IssuerSignedDocument';
 export { DeviceSignedDocument } from './mdoc/model/DeviceSignedDocument';
 export { DeviceResponse } from './mdoc/model/DeviceResponse';
 export { MDLError, MDLParseError } from './mdoc/errors';
+export { VerificationAssessmentId } from './mdoc/checkCallback';

--- a/src/mdoc/checkCallback.ts
+++ b/src/mdoc/checkCallback.ts
@@ -3,12 +3,52 @@ import { MDLError } from './errors';
 
 const log = debug('mdl');
 
+export const VerificationAssessmentId = {
+  ISSUER_AUTH: {
+    IssuerCertificateValidity: 'ISSUER_CERTIFICATE_VALIDITY',
+    IssuerSignatureValidity: 'ISSUER_SIGNATURE_VALIDITY',
+    MsoSignedDateWithinCertificateValidity: 'MSO_SIGNED_DATE_WITHIN_CERTIFICATE_VALIDITY',
+    MsoValidityAtVerificationTime: 'MSO_VALIDITY_AT_VERIFICATION_TIME',
+    IssuerSubjectCountryNamePresence: 'ISSUER_SUBJECT_COUNTRY_NAME_PRESENCE',
+  },
+
+  DEVICE_AUTH: {
+    DocumentDeviceSignaturePresence: 'DOCUMENT_DEVICE_SIGNATURE_PRESENCE',
+    DeviceAuthSignatureOrMacPresence: 'DEVICE_AUTH_SIGNATURE_OR_MAC_PRESENCE',
+    SessionTranscriptProvided: 'SESSION_TRANSCRIPT_PROVIDED',
+    DeviceKeyAvailableInIssuerAuth: 'DEVICE_KEY_AVAILABLE_IN_ISSUERAUTH',
+    DeviceSignatureValidity: 'DEVICE_SIGNATURE_VALIDITY',
+    DeviceMacPresence: 'DEVICE_MAC_PRESENCE',
+    DeviceMacAlgorithmCorrectness: 'DEVICE_MAC_ALGORITHM_CORRECTNESS',
+    EphemeralKeyPresence: 'EPHEMERAL_KEY_PRESENCE',
+    DeviceMacValidity: 'DEVICE_MAC_VALIDITY',
+  },
+
+  DATA_INTEGRITY: {
+    IssuerAuthDigestAlgorithmSupported: 'ISSUER_AUTH_DIGEST_ALGORITHM_SUPPORTED',
+    IssuerAuthNamespaceDigestPresence: 'ISSUER_AUTH_NAMESPACE_DIGEST_PRESENCE',
+    AttributeDigestMatch: 'ATTRIBUTE_DIGEST_MATCH',
+    IssuingCountryMatchesCertificate: 'ISSUING_COUNTRY_MATCHES_CERTIFICATE',
+    IssuingJurisdictionMatchesCertificate: 'ISSUING_JURISDICTION_MATCHES_CERTIFICATE',
+  },
+
+  DOCUMENT_FORMAT: {
+    DeviceResponseVersionPresence: 'DEVICE_RESPONSE_VERSION_PRESENCE',
+    DeviceResponseVersionSupported: 'DEVICE_RESPONSE_VERSION_SUPPORTED',
+    DeviceResponseDocumentPresence: 'DEVICE_RESPONSE_DOCUMENT_PRESENCE',
+  },
+} as const;
+
 export type VerificationAssessment = {
   status: 'PASSED' | 'FAILED' | 'WARNING',
-  category: 'DOCUMENT_FORMAT' | 'DEVICE_AUTH' | 'ISSUER_AUTH' | 'DATA_INTEGRITY',
   check: string,
   reason?: string,
-};
+} & {
+  [C in keyof typeof VerificationAssessmentId]: {
+    category: C;
+    id: typeof VerificationAssessmentId[C][keyof typeof VerificationAssessmentId[C]];
+  };
+}[keyof typeof VerificationAssessmentId];
 
 export type VerificationCallback = (item: VerificationAssessment) => void;
 export type UserDefinedVerificationCallback = (item: VerificationAssessment, original: VerificationCallback) => void;
@@ -16,7 +56,7 @@ export type UserDefinedVerificationCallback = (item: VerificationAssessment, ori
 export const defaultCallback: VerificationCallback = ((verification) => {
   log(`Verification: ${verification.check} => ${verification.status}`);
   if (verification.status !== 'FAILED') return;
-  throw new MDLError(verification.reason ?? verification.check);
+  throw new MDLError(verification.reason ?? verification.check, verification.id);
 });
 
 export const buildCallback = (callback?: UserDefinedVerificationCallback): VerificationCallback => {
@@ -26,8 +66,8 @@ export const buildCallback = (callback?: UserDefinedVerificationCallback): Verif
   };
 };
 
-export const onCatCheck = (onCheck: UserDefinedVerificationCallback, category: VerificationAssessment['category']) => {
-  return (item: Omit<VerificationAssessment, 'category'>) => {
-    onCheck({ ...item, category }, defaultCallback);
+export const onCatCheck = <C extends keyof typeof VerificationAssessmentId>(onCheck: UserDefinedVerificationCallback, category: C) => {
+  return (item: Omit<Extract<VerificationAssessment, { category: C }>, 'category'>) => {
+    onCheck({ ...item, category } as VerificationAssessment, defaultCallback);
   };
 };

--- a/src/mdoc/errors.ts
+++ b/src/mdoc/errors.ts
@@ -1,7 +1,10 @@
 export class MDLError extends Error {
-  constructor(message?: string) {
+  public code?: string;
+
+  constructor(message: string, code?: string) {
     super(message);
     this.name = new.target.name;
+    this.code = code;
     Object.setPrototypeOf(this, new.target.prototype);
   }
 }


### PR DESCRIPTION
Also, this new id is now included as part of the thrown `MDLError`.

closes #45