### PR TITLE
fix: added variableMapSize option for cbor-x encoderDefaults

### DIFF
--- a/src/cbor/index.ts
+++ b/src/cbor/index.ts
@@ -39,6 +39,7 @@ const encoderDefaults: Options = {
   mapsAsObjects: false,
   // @ts-ignore
   useTag259ForMaps: false,
+  variableMapSize: true,
 };
 
 // tdate data item shall contain a date-time string as specified in RFC 3339 (with no fraction of seconds)


### PR DESCRIPTION
As described in [auth0-lab/mdl#48](https://github.com/auth0-lab/mdl/issues/48), using A{0,9} maps where applicable (instead of B9 maps) aligns with the expectations of ISO 18013-5 and resolves interoperability and signature verification issues.

By adding variableMapSize: true to the cbor-x options as recommended by the issue's author, the problem appears to be resolved -particularly in cases like the calculation of DeviceAuthenticationBytes, which includes nameSpaces, one of the maps affected.