### PR TITLE
feat: allow optional customization of cbor encode/decode options

### DIFF
--- a/__tests__/cbor.tests.ts
+++ b/__tests__/cbor.tests.ts
@@ -1,6 +1,6 @@
 import { hex } from 'buffer-tag';
 
-import { cborDecode, cborEncode, DataItem } from '../src/cbor';
+import { cborDecode, cborEncode, DataItem, getCborEncodeDecodeOptions, setCborEncodeDecodeOptions } from '../src/cbor';
 
 describe('cbor', () => {
   it('should properly decode a nested map', () => {
@@ -16,6 +16,18 @@ describe('cbor', () => {
     const decoded = cborDecode(encoded);
     const reEncode = cborEncode(decoded);
     expect(reEncode.toString('hex')).toBe(encoded.toString('hex'));
+    expect(encoded[3].toString(16)).toBe('b9'); // Large Map
+  });
+
+  it('should properly encoded and decoded maps using variableMapSize=true', () => {
+    const options = getCborEncodeDecodeOptions();
+    options.variableMapSize = true;
+    setCborEncodeDecodeOptions(options);
+    const encoded = cborEncode(DataItem.fromData({ foo: 'baz' }));
+    const decoded = cborDecode(encoded);
+    const reEncode = cborEncode(decoded);
+    expect(reEncode.toString('hex')).toBe(encoded.toString('hex'));
+    expect(encoded[3].toString(16)).toBe('a1'); // Map with one item
   });
 
   it('should properly encoded and decoded with arrays', () => {

--- a/src/cbor/index.ts
+++ b/src/cbor/index.ts
@@ -33,7 +33,7 @@ export class DateOnly extends Date {
   }
 }
 
-const encoderDefaults: Options = {
+let encoderDefaults: Options = {
   tagUint8Array: false,
   useRecords: false,
   mapsAsObjects: false,
@@ -58,6 +58,14 @@ addExtension({
   encode: (date: DateOnly, encode) => encode(date.toISOString()),
   decode: (isoStringDate: any): Object => new DateOnly(isoStringDate),
 });
+
+export const getCborEncodeDecodeOptions = () : Options => {
+  return encoderDefaults;
+};
+
+export const setCborEncodeDecodeOptions = (options: Options) : void => {
+  encoderDefaults = options;
+};
 
 export const cborDecode = (
   input: Buffer | Uint8Array,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export { getCborEncodeDecodeOptions, setCborEncodeDecodeOptions } from './cbor';
 export { Verifier } from './mdoc/Verifier';
 export { parse } from './mdoc/parser';
 export { DataItem } from './cbor/DataItem';


### PR DESCRIPTION
Add new functions to src/cbor/index that allow getting and setting of default cbor encode/decode options.

Enhance cbor tests to demonstrate successful use in how maps get encoded.

Addresses issue [auth0-lab/mdl/issues/48](https://github.com/auth0-lab/mdl/issues/48)