### PR TITLE
fix(cbor): added `variableMapSize: true` option for cbor-x defaults

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@panva/hkdf": "^1.1.1",
         "@peculiar/x509": "^1.9.5",
         "buffer": "^6.0.3",
-        "cbor-x": "^1.5.9",
+        "cbor-x": "^1.6.0",
         "compare-versions": "^6.0.0",
         "cose-kit": "^1.7.1",
         "debug": "^4.3.4",
@@ -3391,9 +3391,9 @@
       }
     },
     "node_modules/cbor-x": {
-      "version": "1.5.9",
-      "resolved": "https://registry.npmjs.org/cbor-x/-/cbor-x-1.5.9.tgz",
-      "integrity": "sha512-OEI5rEu3MeR0WWNUXuIGkxmbXVhABP+VtgAXzm48c9ulkrsvxshjjk94XSOGphyAKeNGLPfAxxzEtgQ6rEVpYQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/cbor-x/-/cbor-x-1.6.0.tgz",
+      "integrity": "sha512-0kareyRwHSkL6ws5VXHEf8uY1liitysCVJjlmhaLG+IXLqhSaOO+t63coaso7yjwEzWZzLy8fJo06gZDVQM9Qg==",
       "license": "MIT",
       "optionalDependencies": {
         "cbor-extract": "^2.2.0"
@@ -10664,9 +10664,9 @@
       }
     },
     "cbor-x": {
-      "version": "1.5.9",
-      "resolved": "https://registry.npmjs.org/cbor-x/-/cbor-x-1.5.9.tgz",
-      "integrity": "sha512-OEI5rEu3MeR0WWNUXuIGkxmbXVhABP+VtgAXzm48c9ulkrsvxshjjk94XSOGphyAKeNGLPfAxxzEtgQ6rEVpYQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/cbor-x/-/cbor-x-1.6.0.tgz",
+      "integrity": "sha512-0kareyRwHSkL6ws5VXHEf8uY1liitysCVJjlmhaLG+IXLqhSaOO+t63coaso7yjwEzWZzLy8fJo06gZDVQM9Qg==",
       "requires": {
         "cbor-extract": "^2.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@panva/hkdf": "^1.1.1",
     "@peculiar/x509": "^1.9.5",
     "buffer": "^6.0.3",
-    "cbor-x": "^1.5.9",
+    "cbor-x": "^1.6.0",
     "compare-versions": "^6.0.0",
     "cose-kit": "^1.7.1",
     "debug": "^4.3.4",

--- a/src/cbor/index.ts
+++ b/src/cbor/index.ts
@@ -39,6 +39,7 @@ let encoderDefaults: Options = {
   mapsAsObjects: false,
   // @ts-ignore
   useTag259ForMaps: false,
+  variableMapSize: true,
 };
 
 // tdate data item shall contain a date-time string as specified in RFC 3339 (with no fraction of seconds)


### PR DESCRIPTION
BREAKING CHANGE: maps are now encoded with indefinite length using a break code.

This replaces the previous fixed-length encoding and aligns with CBOR canonical rules.

fixes #57 #48 
closes #51 

Credits to @gsiou and @warren-gallagher